### PR TITLE
Run pytest as a Github action

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,34 @@
+name: Validation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+        poetry-version: [1.1.12]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Set up Poetry ${{ matrix.poetry-version }}
+      uses: abatilo/actions-poetry@v2.0.0
+      with:
+        poetry-version: ${{ matrix.poetry-version }}
+    - name: Install dependencies
+      run: |
+        poetry install
+    - name: Test with pytest
+      run: |
+        poetry run pytest

--- a/git_rex/git.py
+++ b/git_rex/git.py
@@ -29,13 +29,6 @@ def commit_with_meta_from(commit: "Commit") -> None:
 
 
 class Commit:
-    """Wrapper around Git commit commands.
-
-    >>> c = Commit("0e507f394bd3a3a4b96fe3208d14aab469ce1ab9")
-    >>> c.message
-    'Initial gitignore\\n'
-    """
-
     def __init__(self, rev: str):
         p = Popen(["git", "rev-parse", rev], stdout=PIPE, stderr=PIPE)
         stdout, stderr = p.communicate()

--- a/test/unit/test_git.py
+++ b/test/unit/test_git.py
@@ -1,0 +1,28 @@
+import re
+import os
+import pytest
+from subprocess import check_call
+
+from git_rex import git
+
+
+@pytest.fixture
+def temp_working_dir(request, tmp_path):
+    os.chdir(tmp_path)
+    yield
+    os.chdir(request.config.invocation_dir)
+
+
+def test_commit(temp_working_dir):
+    check_call(["git", "init"])
+    with open("file.txt", "w") as file:
+        print("Test file", file=file)
+    check_call(["git", "add", "file.txt"])
+    check_call(["git", "config", "user.email", "unit-test-runner@example.com"])
+    check_call(["git", "config", "user.name", "Unit Test Runner"])
+    check_call(["git", "commit", "-m", "Added a test file"])
+
+    c = git.Commit("HEAD")
+
+    assert c.message == "Added a test file\n"
+    assert re.match(r"^[0-9a-f]{40}$", c.hash)


### PR DESCRIPTION
Additionally, convert doctest for git.Commit into a unit test. While convenient, the doctest unfortunately requires the git-rex git repository be present, which would unnecessarily slow continuous integration.

See also issue #10.