### PR TITLE
Ensure version is bumped in PRs

### DIFF
--- a/.github/scripts/check-version-change.py
+++ b/.github/scripts/check-version-change.py
@@ -1,0 +1,79 @@
+import os
+import re
+import sys
+from subprocess import check_output
+
+import toml
+from gql import Client, gql
+from gql.transport.aiohttp import AIOHTTPTransport
+from packaging import version
+
+# Fetch version information
+new_pyproject = toml.load("pyproject.toml")
+new_name = new_pyproject["tool"]["poetry"]["name"]
+new_version = version.parse(new_pyproject["tool"]["poetry"]["version"])
+old_pyproject_s = check_output(
+    ["git", "show", "origin/main:pyproject.toml"], encoding="utf-8"
+)
+old_pyproject = toml.loads(old_pyproject_s)
+old_name = old_pyproject["tool"]["poetry"]["name"]
+old_version = version.parse(old_pyproject["tool"]["poetry"]["version"])
+print(f"Old {old_name} version: {old_version}")
+print(f"New {new_name} version: {new_version}")
+
+
+def fetch_pr_labels():
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request
+    PR = int(re.match(r"refs/pull/(\d+)/merge", os.environ["GITHUB_REF"]).group(1))
+
+    OWNER, REPO = os.environ["GITHUB_REPOSITORY"].split("/")
+    GITHUB_TOKEN = sys.argv[1]
+    transport = AIOHTTPTransport(
+        url=os.environ["GITHUB_GRAPHQL_URL"],
+        headers={"Authorization": f"Bearer {GITHUB_TOKEN}"},
+    )
+    client = Client(transport=transport, fetch_schema_from_transport=True)
+    result = client.execute(
+        gql(
+            """
+    query getLabels($repo: String!, $owner: String!, $pr: Int!) {
+      repository(name: $repo, owner: $owner) {
+        pullRequest(number: $pr) {
+          labels(first: 100) {
+            nodes {
+              name
+            }
+          }
+        }
+      }
+    }
+  """
+        ),
+        variable_values=dict(repo=REPO, owner=OWNER, pr=PR),
+    )
+    return set(
+        n["name"] for n in result["repository"]["pullRequest"]["labels"]["nodes"]
+    )
+
+
+norelease = "norelease" in fetch_pr_labels()
+
+if old_name != new_name:
+    if norelease:
+        print("norelease PRs cannot change the project name", file=sys.stderr)
+        sys.exit(1)
+elif old_version < new_version:
+    print("Version is older in this PR than on destination branch", file=sys.stderr)
+    sys.exit(1)
+elif old_version >= new_version:
+    if not norelease:
+        print(
+            "PRs must bump the project version prior to merging,"
+            " or be tagged norelease",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+else:
+    if norelease:
+        print("norelease PRs must not bump the project version", file=sys.stderr)
+        sys.exit(1)

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,26 @@
+name: PR standards
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Fetch origin/main
+      run: git remote set-branches origin main && git fetch -v
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v2
+      with:
+        python-version: "3.10"
+    - name: Install python libs
+      run: pip install gql[aiohttp] packaging toml
+    - name: Check pyproject.toml version
+      run: python .github/scripts/check-version-change.py ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Check the version of git-rex in pyproject.toml, and ensure either it is bumped, or the PR has the norelease label.

This should hopefully avoid PRs like #21 in future.