### PR TITLE
Fix error handling

### DIFF
--- a/git_rex/log_config.py
+++ b/git_rex/log_config.py
@@ -1,0 +1,20 @@
+import sys
+from logging import (
+    ERROR,
+    FATAL,
+    WARNING,
+    Formatter,
+    StreamHandler,
+    addLevelName,
+    basicConfig,
+)
+
+
+def configure_logging() -> None:
+    errorHandler = StreamHandler(sys.stderr)
+    errorHandler.setFormatter(Formatter("%(levelname)s: %(message)s"))
+    errorHandler.setLevel(WARNING)
+    basicConfig(handlers=[errorHandler])
+    addLevelName(WARNING, "warn")
+    addLevelName(ERROR, "error")
+    addLevelName(FATAL, "fatal")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-rex"
-version = "0.3.0"
+version = "0.3.1"
 description = ""
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -19,9 +19,11 @@ def assert_git_version(minimum_version):
 def temp_git_repo(request, tmp_path):
     assert_git_version("2.28")  # Needed for `git branch -m` to succeed
     os.chdir(tmp_path)
-    check_call(["git", "init", "--quiet"])
-    check_call(["git", "branch", "-m", "main"])
-    check_call(["git", "config", "user.email", "unit-test-runner@example.com"])
-    check_call(["git", "config", "user.name", "Unit Test Runner"])
-    yield tmp_path
-    os.chdir(request.config.invocation_dir)
+    try:
+        check_call(["git", "init", "--quiet"])
+        check_call(["git", "branch", "-m", "main"])
+        check_call(["git", "config", "user.email", "unit-test-runner@example.com"])
+        check_call(["git", "config", "user.name", "Unit Test Runner"])
+        yield tmp_path
+    finally:
+        os.chdir(request.config.invocation_dir)

--- a/test/system/test_no_git_dir.py
+++ b/test/system/test_no_git_dir.py
@@ -1,0 +1,24 @@
+import os
+import sys
+from subprocess import PIPE, Popen
+
+
+def test_error_message_when_no_git_dir(request, tmp_path, rex):
+    os.chdir(tmp_path)
+    try:
+        rex = Popen(
+            [sys.executable, "-c", "import git_rex ; git_rex.main()", "HEAD"],
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+        stdout_bytes, stderr_bytes = rex.communicate()
+        assert rex.returncode != 0
+        stdout = stdout_bytes.decode("utf-8")
+        stderr = stderr_bytes.decode("utf-8")
+        assert stdout == ""
+        assert (
+            stderr == "fatal: not a git repository "
+            "(or any of the parent directories): .git\n"
+        )
+    finally:
+        os.chdir(request.config.invocation_dir)


### PR DESCRIPTION
We are not trapping the GitFailure thrown by `git.top_level()` if run outside of a git repository. Fixed by consolidating all error logging in the main method, and added a system test of the correct behaviour here so we do not regress in future.

Additionally, switch from `print` to `log` for readability, fixing two cases where we were erroring to stdout rather than stderr by mistake.