### PR TITLE
Refactor: split extract_scripts in two

### DIFF
--- a/git_rex/messages.py
+++ b/git_rex/messages.py
@@ -1,4 +1,5 @@
 import re
+from typing import Iterable, Union
 
 CODE_BLOCK = re.compile(r"\s*```(\w*)\s*$")
 
@@ -21,6 +22,39 @@ class UnterminatedCodeBlock(Exception):
     pass
 
 
+class CodeLine:
+    def __init__(self, text: str):
+        self.text = text
+
+
+class CodeBlockEnd:
+    pass
+
+
+MessageLine = Union[CodeLine, CodeBlockEnd]
+
+
+def parse_message(message: str) -> Iterable[MessageLine]:
+    in_code_block = False
+    lines = message.splitlines()
+    for lineno, line in enumerate(lines, start=1):
+        if not in_code_block:
+            if m := CODE_BLOCK.match(line):
+                if m.group(1) != "bash":
+                    raise UnsupportedCodeSyntax(lineno)
+                in_code_block = True
+        else:
+            if m := CODE_BLOCK.match(line):
+                if m.group(1):
+                    raise UnexpectedCodeBlock(lineno)
+                in_code_block = False
+                yield CodeBlockEnd()
+            else:
+                yield CodeLine(line)
+    if in_code_block:
+        raise UnterminatedCodeBlock(lineno, line)
+
+
 def extract_scripts(message: str) -> tuple[tuple[str, ...], ...]:
     """Extracts code from between triple-tick blocks
 
@@ -40,27 +74,14 @@ def extract_scripts(message: str) -> tuple[tuple[str, ...], ...]:
     >>> extract_scripts(commit_message)
     (('run_my_code thing', 'and_my_other thing'), ('run_a_third thing',))
     """
-    in_code_block = False
-    lines = message.splitlines()
     code_blocks = []
     code_lines: list[str] = []
-    for lineno, line in enumerate(lines, start=1):
-        if not in_code_block:
-            if m := CODE_BLOCK.match(line):
-                if m.group(1) != "bash":
-                    raise UnsupportedCodeSyntax(lineno)
-                in_code_block = True
-        else:
-            if m := CODE_BLOCK.match(line):
-                if m.group(1):
-                    raise UnexpectedCodeBlock(lineno)
-                code_blocks.append(tuple(code_lines))
-                code_lines.clear()
-                in_code_block = False
-            elif line.strip():
-                code_lines.append(line.strip())
-    if in_code_block:
-        raise UnterminatedCodeBlock()
+    for line in parse_message(message):
+        if isinstance(line, CodeLine):
+            code_lines.append(line.text.strip())
+        elif isinstance(line, CodeBlockEnd):
+            code_blocks.append(tuple(code_lines))
+            code_lines.clear()
     if not code_blocks:
         raise NoCodeFound()
     return tuple(code_blocks)


### PR DESCRIPTION
parse_message now handles the state machine of whether we are in a code block or not, while extract_scripts collects and returns code blocks