### PR TITLE
Add --edit flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@ Alternative to git cherry-pick that finds and runs commands in the commit messag
 
 [![Validation status page](https://github.com/alicederyn/git-rex/actions/workflows/validation.yml/badge.svg?branch=main)](https://github.com/alicederyn/git-rex/actions/workflows/validation.yml?query=branch%3Amain)
 
-For instance, suppose `git rebase -i` gives the following script:
+
+Reexecuting
+-----------
+
+Suppose `git rebase -i` gives the following script:
 
 ```
 pick 151779 Add new feature
@@ -19,8 +23,11 @@ edit 151779 Add new feature
 x git rex 2332c1 # Automatic code reformatting
 ```
 
-Note that rex only supports scripts in a [Markdown fenced code block] with
-[bash syntax highlighting]:
+
+Commit messages
+---------------
+
+Rex only supports scripts in a [Markdown fenced code block] with [bash syntax highlighting]:
 
 ````
 Automatic code reformatting
@@ -40,6 +47,24 @@ variables, or directory changes) persist until the end of a code black. Each scr
 
 [Markdown fenced code block]: https://www.markdownguide.org/extended-syntax/#fenced-code-blocks
 [bash syntax highlighting]: https://www.markdownguide.org/extended-syntax/#syntax-highlighting
+
+
+Command-line options
+--------------------
+
+### `-e`, `--edit`
+
+Before executing a commit script, opens the commit message in an editor for amendment. Unlike
+in regular `git commit`, comments within scripts will not be removed from the edit message.
+The author and timestamp of the original commit will be discarded.
+
+If this flag is provided, the commit can optionally be missed off the invocation completely:
+
+```bash
+git rex --edit
+```
+
+In this case, a template commit message will be opened.
 
 
 Forwards-compatibility

--- a/git_rex/__init__.py
+++ b/git_rex/__init__.py
@@ -3,19 +3,38 @@ import sys
 from logging import getLogger
 from optparse import OptionParser, Values
 from subprocess import DEVNULL, call
+from typing import Optional
 
 from . import git
+from .editor import EditorError, EditorUnset, spawn_editor
 from .log_config import configure_logging
 from .messages import (
     NoCodeFound,
     UnexpectedCodeBlock,
     UnsupportedCodeSyntax,
     UnterminatedCodeBlock,
+    cleanup_message,
     extract_scripts,
 )
 
 TEMP_REX_SCRIPT = ".git/REX_SCRIPT"
 log = getLogger(__name__)
+
+DEFAULT_COMMIT_TEMPLATE = """Automated commit created with git-rex
+
+The following commands were executed:
+
+# Enter your script here. It will be executed, and all files created
+# or changed committed to your repository.
+```bash
+
+```
+
+# Please enter the commit message for your changes. Lines starting
+# with '#', except those in script sections, will be ignored, and an
+# empty commit message, or one with no script commands to execute,
+# aborts the commit.
+"""
 
 
 class UnstagedChanges(Exception):
@@ -27,10 +46,8 @@ class UserCodeError(Exception):
         self.resultcode = resultcode
 
 
-def reexecute(commit: git.Commit) -> None:
-    if not git.is_clean_repo():
-        raise UnstagedChanges()
-    scripts = extract_scripts(commit.message)
+def run_scripts(commit_message: str) -> None:
+    scripts = extract_scripts(commit_message)
     try:
         for script in scripts:
             with open(TEMP_REX_SCRIPT, "w") as f:
@@ -41,15 +58,33 @@ def reexecute(commit: git.Commit) -> None:
                 raise UserCodeError(resultcode)
     finally:
         os.remove(TEMP_REX_SCRIPT)
+
+
+def reexecute_commit(commit: git.Commit) -> None:
+    """git rex commit"""
+    run_scripts(commit.message)
     git.add_all()
     git.commit_with_meta_from(commit)
 
 
+def edit_commit(commit: Optional[git.Commit]) -> None:
+    """git rex --edit [commit]"""
+    original_message = commit.message if commit else DEFAULT_COMMIT_TEMPLATE
+    raw_edited_message = spawn_editor(original_message, filename=".git/COMMIT_EDITMSG")
+    commit_message = cleanup_message(raw_edited_message)
+    run_scripts(commit_message)
+    git.add_all()
+    git.commit(commit_message)
+
+
 def parser() -> OptionParser:
-    usage = "Usage: %prog commit"
+    usage = "Usage: %prog [options] [commit]"
     description = "Reapplies a commit by running commands from the commit message"
 
     parser = OptionParser(usage=usage, description=description)
+    parser.add_option(
+        "-e", "--edit", action="store_true", help="Edit commit message before executing"
+    )
     return parser
 
 
@@ -67,18 +102,28 @@ def parse_options() -> Values:
 def main() -> None:
     configure_logging()
     options = parse_options()
-    if not options.commit:
-        parser().print_help()
-        sys.exit(64)
     try:
         os.chdir(git.top_level())
-        reexecute(commit=options.commit)
+
+        if not git.is_clean_repo():
+            raise UnstagedChanges()
+
+        if options.edit:
+            edit_commit(options.commit)
+        else:
+            if not options.commit:
+                parser().print_help()
+                sys.exit(64)
+            reexecute_commit(options.commit)
     except UnstagedChanges:
         log.error("cannot reexecute: You have unstaged changes.")
         log.error("Please commit or stash them.")
         sys.exit(64)
     except NoCodeFound:
-        log.fatal("No code section found in commit")
+        if options.edit:
+            log.fatal("Aborting commit as no code found to execute")
+        else:
+            log.fatal("No code section found in commit")
         sys.exit(64)
     except UnsupportedCodeSyntax as e:
         log.fatal("%d: Code sections must specify bash syntax", e.lineno)
@@ -88,6 +133,12 @@ def main() -> None:
         sys.exit(64)
     except UnterminatedCodeBlock:
         log.fatal("Code block not terminated in commit message")
+        sys.exit(64)
+    except EditorUnset:
+        log.error("Terminal is dumb, but EDITOR unset")
+        sys.exit(64)
+    except EditorError as e:
+        log.error("There was a problem with the editor %s", e.editor_command)
         sys.exit(64)
     except git.GitFailure as e:
         log.fatal("%s", e.message)

--- a/git_rex/editor.py
+++ b/git_rex/editor.py
@@ -1,0 +1,48 @@
+import os
+from shlex import quote
+from subprocess import call
+
+from .git import core_editor
+
+
+class EditorUnset(Exception):
+    pass
+
+
+class EditorError(Exception):
+    def __init__(self, editor_command, returncode):
+        self.editor_command = editor_command
+        self.returncode = returncode
+
+
+def is_terminal_dumb() -> bool:
+    # Copied from editor.c in git
+    term = os.getenv("TERM")
+    return not term or term == "dumb"
+
+
+def editor_command() -> str:
+    # Copied from editor.c in git
+    editor = os.getenv("GIT_EDITOR")
+    if not editor:
+        editor = core_editor()
+    if not editor and not is_terminal_dumb():
+        editor = os.getenv("VISUAL")
+    if not editor:
+        editor = os.getenv("EDITOR")
+    if not editor and is_terminal_dumb():
+        raise EditorUnset()
+    if not editor:
+        editor = "vi"
+    return editor
+
+
+def spawn_editor(initial_text: str, *, filename: str) -> str:
+    with open(filename, "w") as f:
+        f.write(initial_text)
+    edit_cmd = editor_command()
+    returncode = call(f"{edit_cmd} {quote(filename)}", shell=True)
+    if returncode != 0:
+        raise EditorError(edit_cmd, returncode)
+    with open(filename) as f:
+        return f.read()

--- a/git_rex/git.py
+++ b/git_rex/git.py
@@ -12,7 +12,12 @@ def git(*args: str) -> bytes:
     p = Popen(["git", *args], stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
-        raise GitFailure(stderr.decode("utf-8").splitlines()[0].removeprefix("fatal: "))
+        try:
+            raise GitFailure(
+                stderr.decode("utf-8").splitlines()[0].removeprefix("fatal: ")
+            )
+        except IndexError:
+            raise GitFailure("") from None
     return stdout
 
 
@@ -23,6 +28,16 @@ def is_clean_repo() -> bool:
 
 def add_all() -> None:
     git("add", "-A")
+
+
+def core_editor() -> str:
+    p = Popen(["git", "config", "core.editor"], stdout=PIPE)
+    stdout, _ = p.communicate()
+    return stdout.decode("ascii").strip()
+
+
+def commit(commit_message: str) -> None:
+    git("commit", "-m", commit_message)
 
 
 def commit_with_meta_from(commit: "Commit") -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -233,6 +233,17 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.1.0"
+description = "pytest plugin to abort hanging tests"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pytest = ">=5.0.0"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -259,7 +270,7 @@ python-versions = ">=3.6"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f20c31cf332e5d8831f45e945bda63de604ee8ec92972417055feecfcf1ac130"
+content-hash = "cc90348813be4d587fc707003c1989cb1bd8dea2d27edd36aa296adc211c8459"
 
 [metadata.files]
 atomicwrites = [
@@ -359,6 +370,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+pytest-timeout = [
+    {file = "pytest-timeout-2.1.0.tar.gz", hash = "sha256:c07ca07404c612f8abbe22294b23c368e2e5104b521c1790195561f37e1ac3d9"},
+    {file = "pytest_timeout-2.1.0-py3-none-any.whl", hash = "sha256:f6f50101443ce70ad325ceb4473c4255e9d74e3c7cd0ef827309dfa4c0d975c6"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ pytest = "^6.2.5"
 isort = "^5.10.1"
 flake8 = "^4.0.1"
 mypy = "^0.931"
+pytest-timeout = "^2.1.0"
 
 [tool.isort]
 profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-rex"
-version = "0.3.2"
+version = "0.4.0"
 description = ""
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 

--- a/test/system/conftest.py
+++ b/test/system/conftest.py
@@ -5,6 +5,8 @@ import pytest
 
 import git_rex
 
+from .mock_editor import MockEditor
+
 
 @pytest.fixture
 def rex():
@@ -19,3 +21,9 @@ def rex():
             os.chdir(cwd)
 
     return invoke_rex
+
+
+@pytest.fixture
+def mock_editor(temp_git_repo):
+    with MockEditor() as mock_editor:
+        yield mock_editor

--- a/test/system/mock_editor/__init__.py
+++ b/test/system/mock_editor/__init__.py
@@ -1,0 +1,3 @@
+from .mock_editor import MockEditor
+
+__all__ = ["MockEditor"]

--- a/test/system/mock_editor/__main__.py
+++ b/test/system/mock_editor/__main__.py
@@ -1,0 +1,18 @@
+import json
+import sys
+
+ARGV_FILE = ".git/MOCK_EDITOR_ARGV"
+EXIT_CODE_FILE = ".git/MOCK_EDITOR_EXIT_CODE"
+
+
+def main() -> None:
+    """Substitute editor, to test git code"""
+    with open(ARGV_FILE, "w") as f:
+        json.dump(sys.argv, f)
+    with open(EXIT_CODE_FILE) as f:
+        return_code = int(f.readline())
+    sys.exit(return_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/system/mock_editor/mock_editor.py
+++ b/test/system/mock_editor/mock_editor.py
@@ -1,0 +1,35 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+ARGV_FILE = ".git/MOCK_EDITOR_ARGV"
+EXIT_CODE_FILE = ".git/MOCK_EDITOR_EXIT_CODE"
+SCRIPT_DIR = Path(__file__).parent
+
+
+class MockEditor:
+    def __enter__(self) -> "MockEditor":
+        os.mkfifo(ARGV_FILE)
+        os.mkfifo(EXIT_CODE_FILE)
+        self._exit_code_written = False
+        return self
+
+    def __exit__(self, type, value, traceback) -> None:
+        if not self._exit_code_written:
+            with open(EXIT_CODE_FILE, "w") as f:
+                f.write("-1\n")
+
+    def env(self) -> dict[str, str]:
+        return {"EDITOR": f"{sys.executable} {SCRIPT_DIR}"}
+
+    def filename(self) -> str:
+        with open(ARGV_FILE) as f:
+            _, filename = json.load(f)
+        assert isinstance(filename, str)
+        return filename
+
+    def exit_editor(self, return_code=0) -> None:
+        with open(EXIT_CODE_FILE, "w") as f:
+            f.write(f"{return_code}\n")
+        self._exit_code_written = True

--- a/test/system/test_rex_edit.py
+++ b/test/system/test_rex_edit.py
@@ -1,0 +1,52 @@
+"""Verify invoking rex with `git rex --edit`."""
+
+import sys
+from subprocess import Popen, check_output
+
+import pytest
+
+from .mock_editor import MockEditor
+
+COMMIT_MESSAGE = """My commit
+
+```bash
+# This comment should be preserved
+echo "Text" > file.txt
+```
+
+"""
+
+POST_COMMIT_COMMENT = """
+# This comment should be removed
+"""
+
+
+@pytest.mark.timeout(1)
+def test_edit_flag_opens_editor(temp_git_repo, mock_editor: MockEditor):
+    rex = Popen(
+        [sys.executable, "-c", "import git_rex ; git_rex.main()", "--edit"],
+        env=mock_editor.env(),
+    )
+
+    commit_file = mock_editor.filename()
+    with open(commit_file) as f:
+        txt = f.read()
+        assert "Enter your script here" in txt
+
+    with open(commit_file, "w") as f:
+        f.write(COMMIT_MESSAGE)
+        f.write(POST_COMMIT_COMMENT)
+
+    mock_editor.exit_editor()
+    assert rex.wait() == 0
+
+    # Ensure file.txt was created correctly
+    with open("file.txt") as f:
+        file_txt = f.read().splitlines()
+    assert file_txt == ["Text"]
+
+    # Ensure commit comments were handled correctly
+    commit_message = check_output(
+        ["git", "show", "-s", "--format=%B"], encoding="utf-8"
+    )
+    assert commit_message == COMMIT_MESSAGE

--- a/test/system/test_rex_edit_commit.py
+++ b/test/system/test_rex_edit_commit.py
@@ -1,0 +1,66 @@
+"""Verify invoking rex with `git rex --edit COMMIT`."""
+
+import sys
+from subprocess import Popen, check_call, check_output
+
+import pytest
+
+from .mock_editor import MockEditor
+
+ORIGINAL_COMMIT_MESSAGE = """Someone's commit
+
+```bash
+# This comment should be preserved
+echo "Incorrect text" > file.txt
+```
+"""
+
+COMMIT_MESSAGE = """My commit
+
+```bash
+# This comment should be preserved
+echo "Text" > file.txt
+```
+
+"""
+
+POST_COMMIT_COMMENT = """
+# This comment should be removed
+"""
+
+
+@pytest.mark.timeout(1)
+def test_edit_flag_opens_editor(temp_git_repo, mock_editor: MockEditor):
+    check_call(["git", "commit", "--allow-empty", "-m", "Initial commit"])
+    check_call(["git", "checkout", "-b", "somebranch"])
+    check_call(["git", "commit", "--allow-empty", "-m", ORIGINAL_COMMIT_MESSAGE])
+    COMMIT = check_output(["git", "rev-parse", "HEAD"], encoding="ascii").strip()
+    check_call(["git", "checkout", "main"])
+
+    rex = Popen(
+        [sys.executable, "-c", "import git_rex ; git_rex.main()", "--edit", COMMIT],
+        env=mock_editor.env(),
+    )
+
+    commit_file = mock_editor.filename()
+    with open(commit_file) as f:
+        txt = f.read()
+        assert txt == ORIGINAL_COMMIT_MESSAGE
+
+    with open(commit_file, "w") as f:
+        f.write(COMMIT_MESSAGE)
+        f.write(POST_COMMIT_COMMENT)
+
+    mock_editor.exit_editor()
+    assert rex.wait() == 0
+
+    # Ensure file.txt was created correctly
+    with open("file.txt") as f:
+        file_txt = f.read().splitlines()
+    assert file_txt == ["Text"]
+
+    # Ensure commit comments were handled correctly
+    commit_message = check_output(
+        ["git", "show", "-s", "--format=%B"], encoding="utf-8"
+    )
+    assert commit_message == COMMIT_MESSAGE

--- a/test/unit/test_cleanup_message.py
+++ b/test/unit/test_cleanup_message.py
@@ -1,0 +1,44 @@
+import pytest
+
+from git_rex.messages import (
+    NoCodeFound,
+    UnexpectedCodeBlock,
+    UnsupportedCodeSyntax,
+    UnterminatedCodeBlock,
+    cleanup_message,
+)
+
+
+def test_removes_comments_only_outside_of_code_blocks():
+    message = "My commit\n\n# A comment\n```bash\n# do a thing\ndo_thing\n```\n"
+    cleaned_message = cleanup_message(message)
+    assert cleaned_message == "My commit\n\n```bash\n# do a thing\ndo_thing\n```\n"
+
+
+def test_no_code_block():
+    with pytest.raises(NoCodeFound):
+        cleanup_message("Some commit\n\nNo code")
+
+
+def test_unterminated_code_block():
+    with pytest.raises(UnterminatedCodeBlock):
+        cleanup_message("Some commit\n\n```bash\ndo a thing")
+
+
+def test_no_bash_label():
+    with pytest.raises(UnsupportedCodeSyntax) as ex:
+        cleanup_message("Some commit\n\n```\ndo a thing\n```")
+
+    assert ex.value.lineno == 3
+
+
+def test_label_on_closing_ticks():
+    with pytest.raises(UnexpectedCodeBlock) as ex:
+        cleanup_message("Some commit\n\n```bash\ndo a thing\n```bash")
+
+    assert ex.value.lineno == 5
+
+
+def test_only_blank_lines_and_comments_in_code():
+    with pytest.raises(NoCodeFound):
+        cleanup_message("Some commit\n\n```bash\n\n# a comment\n\n```")


### PR DESCRIPTION
This can be used with or without a COMMIT. It will open an editor (either populated with the commit message or a default template), and once the editor is closed, will run the script in the commit message, in the same manner as `git rex COMMIT`.

System tests rely on the new mock_editor fixture, which allows verification of behaviours that would normally involve user interaction via vi or some other visual editor

This closes #5.