### PR TITLE
Restore ability to run under python 3.8

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
         poetry-version: [1.1.12]
@@ -28,9 +28,9 @@ jobs:
     - name: Install dependencies
       run: |
         poetry install
-    - name: Check formatting with black
+    - name: Test with pytest
       run: |
-        poetry run black --check .
+        poetry run pytest .
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -52,7 +52,7 @@ jobs:
         poetry install
     - name: Check typing with mypy
       run: |
-        poetry run mypy .
+        poetry run mypy --python-version 3.8 .
     - name: Check style with flake8
       run: |
         poetry run flake8

--- a/git_rex/git.py
+++ b/git_rex/git.py
@@ -8,13 +8,18 @@ class GitFailure(Exception):
         self.message = message
 
 
+def removeprefix(s: str, prefix: str):
+    """Same as s.removeprefix(prefix), added in Python 3.9."""
+    return s[len(prefix) :] if s.startswith(prefix) else s
+
+
 def git(*args: str) -> bytes:
     p = Popen(["git", *args], stdout=PIPE, stderr=PIPE)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
         try:
             raise GitFailure(
-                stderr.decode("utf-8").splitlines()[0].removeprefix("fatal: ")
+                removeprefix(stderr.decode("utf-8").splitlines()[0], "fatal: ")
             )
         except IndexError:
             raise GitFailure("") from None
@@ -55,7 +60,7 @@ def commit_with_meta_from(commit: "Commit") -> None:
 
 
 def top_level() -> Path:
-    return Path(git("rev-parse", "--show-toplevel").decode("utf-8").removesuffix("\n"))
+    return Path(git("rev-parse", "--show-toplevel").decode("utf-8").strip())
 
 
 class Commit:

--- a/git_rex/messages.py
+++ b/git_rex/messages.py
@@ -1,5 +1,5 @@
 import re
-from typing import Iterable, Union
+from typing import Iterable, List, Tuple, Union
 
 CODE_BLOCK = re.compile(r"\s*```(\w*)\s*$")
 
@@ -69,7 +69,7 @@ def parse_message(message: str) -> Iterable[MessageLine]:
         raise UnterminatedCodeBlock(lineno, line)
 
 
-def extract_scripts(message: str) -> tuple[tuple[str, ...], ...]:
+def extract_scripts(message: str) -> Tuple[Tuple[str, ...], ...]:
     """Extracts code from between triple-tick blocks
 
     >>> commit_message = '''Sample commit
@@ -89,7 +89,7 @@ def extract_scripts(message: str) -> tuple[tuple[str, ...], ...]:
     (('run_my_code thing', 'and_my_other thing'), ('run_a_third thing',))
     """
     code_blocks = []
-    code_lines: list[str] = []
+    code_lines: List[str] = []
     for line in parse_message(message):
         if isinstance(line, CodeLine):
             code_lines.append(line.text.strip())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-rex"
-version = "0.5.0"
+version = "0.5.1"
 description = ""
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,10 +5,14 @@ import pytest
 from packaging import version
 
 
+def removeprefix(str, prefix):
+    return str[len(prefix) :] if str.startswith(prefix) else str
+
+
 def assert_git_version(minimum_version):
     git_version = version.parse(
-        check_output(["git", "--version"], encoding="ascii").removeprefix(
-            "git version "
+        removeprefix(
+            check_output(["git", "--version"], encoding="ascii"), "git version "
         )
     )
     if git_version < version.parse(minimum_version):

--- a/test/system/mock_editor/mock_editor.py
+++ b/test/system/mock_editor/mock_editor.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 from pathlib import Path
+from typing import Dict
 
 ARGV_FILE = ".git/MOCK_EDITOR_ARGV"
 EXIT_CODE_FILE = ".git/MOCK_EDITOR_EXIT_CODE"
@@ -20,7 +21,7 @@ class MockEditor:
             with open(EXIT_CODE_FILE, "w") as f:
                 f.write("-1\n")
 
-    def env(self) -> dict[str, str]:
+    def env(self) -> Dict[str, str]:
         return {"EDITOR": f"{sys.executable} {SCRIPT_DIR}"}
 
     def filename(self) -> str:


### PR DESCRIPTION
Remove uses of the following features that are only available in Python 3.9+:

- `dict[...]`, `list[...]` and `tuple[...]` in type hints
- `str.removeprefix` and `str.removesuffix`

Additionally, fix a break in the CI configuration that was accidentally running black instead of pytest, and configure mypy with `--python-version 3.8`, either of which would have caught these issues before they merged.

This fixes #39.