### PR TITLE
Output an error message if a command fails

### DIFF
--- a/git_rex/bash.py
+++ b/git_rex/bash.py
@@ -10,17 +10,36 @@ class UserCodeError(Exception):
         self.resultcode = resultcode
 
 
+def script_preamble(first_lineno):
+    preamble = [
+        "set -eo pipefail",
+        """trap 'echo "error: $((LINENO+(%(offset)d))): """
+        """'"'"'$BASH_COMMAND'"'"' returned status code $?" >&2' ERR""",
+    ]
+    offset = first_lineno - len(preamble) - 1
+    return "\n".join(preamble) % dict(offset=offset)
+
+
 class BashScript:
-    def __init__(self, script: Tuple[str, ...]):
+    def __init__(self, first_lineno: int, script: Tuple[str, ...]):
+        self.first_lineno = first_lineno
         self.script = script
 
     def __repr__(self):
-        return f"BashScript({repr(self.script)})"
+        return (
+            f"BashScript(first_lineno={self.first_lineno}, script={repr(self.script)})"
+        )
+
+    def __str__(self):
+        return "\n".join(
+            f"{lineno}: {line}"
+            for (lineno, line) in enumerate(self.script, start=self.first_lineno)
+        )
 
     def execute(self) -> None:
         try:
             with open(TEMP_REX_SCRIPT, "w") as f:
-                print("set -eo pipefail", file=f)
+                print(script_preamble(self.first_lineno), file=f)
                 print("\n".join(self.script), file=f)
             resultcode = call(["bash", TEMP_REX_SCRIPT], stdin=DEVNULL)
             if resultcode != 0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-rex"
-version = "0.5.1"
+version = "0.5.2"
 description = ""
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,5 @@
+set -e
+trap 'echo "fatal: $LINENO: '"'"'$BASH_COMMAND'"'"' returned status code $?"' ERR
+echo hi there
+false
+echo hi again

--- a/test/unit/test_bash.py
+++ b/test/unit/test_bash.py
@@ -36,7 +36,7 @@ def test_fail_if_any_pipe_component_fails(temp_working_dir):
         script.execute()
 
 
-def test_no_interactive_prompts(temp_working_dir, capfd: pytest.CaptureFixture[str]):
+def test_no_interactive_prompts(temp_working_dir):
     pyscript = """
         from git_rex.bash import BashScript
         script = BashScript(("cat > file.txt",))

--- a/test/unit/test_bash.py
+++ b/test/unit/test_bash.py
@@ -6,15 +6,6 @@ import pytest
 
 from git_rex.bash import BashScript, UserCodeError
 
-SINGLE_SCRIPT_COMMIT_MESSAGE = """Create foo/file.txt
-
-```bash
-mkdir foo
-cd foo
-echo 'New file created by rex-commit' > file.txt
-```
-"""
-
 
 def test_change_directory_in_script(temp_working_dir):
     script = BashScript(


### PR DESCRIPTION
The error will be of the form:

```
error: N: 'COMMAND' returned status code CODE
```

where `N` is the line number of the command in the original commit message, `COMMAND` is the exact command that failed, and `CODE` is its (non-zero) return code.

This fixes #27.