### PR TITLE
Unify rex invocation in system tests

### DIFF
--- a/test/system/conftest.py
+++ b/test/system/conftest.py
@@ -13,12 +13,11 @@ class Rex:
     def __init__(self):
         self.env = None
 
-    def __call__(self, *args, stdout=None, stderr=None) -> Popen:
+    def __call__(self, *args, **kwargs) -> Popen:
         return Popen(
             [sys.executable, "-c", "import git_rex ; git_rex.main()", *args],
             env=self.env,
-            stdout=stdout,
-            stderr=stderr,
+            **kwargs
         )
 
 

--- a/test/system/conftest.py
+++ b/test/system/conftest.py
@@ -1,29 +1,34 @@
-import os
 import sys
+from subprocess import Popen
+from typing import Dict, Iterable, Optional
 
 import pytest
-
-import git_rex
 
 from .mock_editor import MockEditor
 
 
+class Rex:
+    env: Optional[Dict[str, str]]
+
+    def __init__(self):
+        self.env = None
+
+    def __call__(self, *args, stdout=None, stderr=None) -> Popen:
+        return Popen(
+            [sys.executable, "-c", "import git_rex ; git_rex.main()", *args],
+            env=self.env,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+
 @pytest.fixture
-def rex():
-    def invoke_rex(*args: str):
-        argv_copy = list(sys.argv)
-        cwd = os.getcwd()
-        try:
-            sys.argv[:] = ["git-rex", *args]
-            git_rex.main()
-        finally:
-            sys.argv[:] = argv_copy
-            os.chdir(cwd)
-
-    return invoke_rex
+def rex() -> Rex:
+    return Rex()
 
 
 @pytest.fixture
-def mock_editor(temp_git_repo):
+def mock_editor(temp_git_repo, rex: Rex) -> Iterable[MockEditor]:
     with MockEditor() as mock_editor:
+        rex.env = mock_editor.env()
         yield mock_editor

--- a/test/system/test_bash_shell.py
+++ b/test/system/test_bash_shell.py
@@ -37,7 +37,7 @@ def test_commands_run_in_bash(rex, temp_git_repo):
     check_call(["git", "commit", "--allow-empty", "-m", COMMIT_MESSAGE])
     COMMIT = check_output(["git", "rev-parse", "HEAD"], encoding="ascii").strip()
 
-    rex(COMMIT)
+    assert rex(COMMIT).wait() == 0
 
     file3_txt = open("file3.txt").read().splitlines()
     assert file3_txt == ["1a2", "> And another MARKED line"]

--- a/test/system/test_no_git_dir.py
+++ b/test/system/test_no_git_dir.py
@@ -5,11 +5,9 @@ from subprocess import PIPE
 def test_error_message_when_no_git_dir(request, tmp_path, rex):
     os.chdir(tmp_path)
     try:
-        p = rex("HEAD", stdout=PIPE, stderr=PIPE)
-        stdout_bytes, stderr_bytes = p.communicate()
+        p = rex("HEAD", stdout=PIPE, stderr=PIPE, encoding="utf-8")
+        stdout, stderr = p.communicate()
         assert p.returncode != 0
-        stdout = stdout_bytes.decode("utf-8")
-        stderr = stderr_bytes.decode("utf-8")
         assert stdout == ""
         assert (
             stderr == "fatal: not a git repository "

--- a/test/system/test_no_git_dir.py
+++ b/test/system/test_no_git_dir.py
@@ -1,18 +1,13 @@
 import os
-import sys
-from subprocess import PIPE, Popen
+from subprocess import PIPE
 
 
 def test_error_message_when_no_git_dir(request, tmp_path, rex):
     os.chdir(tmp_path)
     try:
-        rex = Popen(
-            [sys.executable, "-c", "import git_rex ; git_rex.main()", "HEAD"],
-            stdout=PIPE,
-            stderr=PIPE,
-        )
-        stdout_bytes, stderr_bytes = rex.communicate()
-        assert rex.returncode != 0
+        p = rex("HEAD", stdout=PIPE, stderr=PIPE)
+        stdout_bytes, stderr_bytes = p.communicate()
+        assert p.returncode != 0
         stdout = stdout_bytes.decode("utf-8")
         stderr = stderr_bytes.decode("utf-8")
         assert stdout == ""

--- a/test/system/test_rex_commit.py
+++ b/test/system/test_rex_commit.py
@@ -37,10 +37,15 @@ def test_rex_commit(rex, temp_git_repo):
     check_call(["git", "commit", "-m", "Append a line"])
 
     # A simple cherry-pick would fail at this point
-    cherrypick = Popen(["git", "cherry-pick", "-n", COMMIT], stdout=PIPE, stderr=STDOUT)
+    cherrypick = Popen(
+        ["git", "cherry-pick", "-n", COMMIT],
+        stdout=PIPE,
+        stderr=STDOUT,
+        encoding="utf-8",
+    )
     stdout, _ = cherrypick.communicate()
     assert cherrypick.returncode != 0
-    assert "Merge conflict in file.txt" in stdout.decode("utf-8")
+    assert "Merge conflict in file.txt" in stdout
 
     check_call(["git", "reset", "--hard", "HEAD"])
 

--- a/test/system/test_rex_commit.py
+++ b/test/system/test_rex_commit.py
@@ -45,7 +45,7 @@ def test_rex_commit(rex, temp_git_repo):
     check_call(["git", "reset", "--hard", "HEAD"])
 
     # git-rex should succeed
-    rex(COMMIT)
+    assert rex(COMMIT).wait() == 0
 
     # Verify the file contains the right contents
     file_txt = open("file.txt").read().splitlines()

--- a/test/system/test_rex_edit.py
+++ b/test/system/test_rex_edit.py
@@ -1,7 +1,6 @@
 """Verify invoking rex with `git rex --edit`."""
 
-import sys
-from subprocess import Popen, check_output
+from subprocess import check_output
 
 import pytest
 
@@ -22,11 +21,8 @@ POST_COMMIT_COMMENT = """
 
 
 @pytest.mark.timeout(1)
-def test_edit_flag_opens_editor(temp_git_repo, mock_editor: MockEditor):
-    rex = Popen(
-        [sys.executable, "-c", "import git_rex ; git_rex.main()", "--edit"],
-        env=mock_editor.env(),
-    )
+def test_edit_flag_opens_editor(rex, mock_editor: MockEditor):
+    p = rex("--edit")
 
     commit_file = mock_editor.filename()
     with open(commit_file) as f:
@@ -38,7 +34,7 @@ def test_edit_flag_opens_editor(temp_git_repo, mock_editor: MockEditor):
         f.write(POST_COMMIT_COMMENT)
 
     mock_editor.exit_editor()
-    assert rex.wait() == 0
+    assert p.wait() == 0
 
     # Ensure file.txt was created correctly
     with open("file.txt") as f:

--- a/test/system/test_rex_edit_commit.py
+++ b/test/system/test_rex_edit_commit.py
@@ -1,7 +1,6 @@
 """Verify invoking rex with `git rex --edit COMMIT`."""
 
-import sys
-from subprocess import Popen, check_call, check_output
+from subprocess import check_call, check_output
 
 import pytest
 
@@ -30,17 +29,14 @@ POST_COMMIT_COMMENT = """
 
 
 @pytest.mark.timeout(1)
-def test_edit_flag_opens_editor(temp_git_repo, mock_editor: MockEditor):
+def test_edit_flag_opens_editor(rex, mock_editor: MockEditor):
     check_call(["git", "commit", "--allow-empty", "-m", "Initial commit"])
     check_call(["git", "checkout", "-b", "somebranch"])
     check_call(["git", "commit", "--allow-empty", "-m", ORIGINAL_COMMIT_MESSAGE])
     COMMIT = check_output(["git", "rev-parse", "HEAD"], encoding="ascii").strip()
     check_call(["git", "checkout", "main"])
 
-    rex = Popen(
-        [sys.executable, "-c", "import git_rex ; git_rex.main()", "--edit", COMMIT],
-        env=mock_editor.env(),
-    )
+    p = rex("--edit", COMMIT)
 
     commit_file = mock_editor.filename()
     with open(commit_file) as f:
@@ -52,7 +48,7 @@ def test_edit_flag_opens_editor(temp_git_repo, mock_editor: MockEditor):
         f.write(POST_COMMIT_COMMENT)
 
     mock_editor.exit_editor()
-    assert rex.wait() == 0
+    assert p.wait() == 0
 
     # Ensure file.txt was created correctly
     with open("file.txt") as f:

--- a/test/system/test_rex_nocommit.py
+++ b/test/system/test_rex_nocommit.py
@@ -29,7 +29,7 @@ def test_rex_commit(rex, temp_git_repo):
         f.write("some text")
     check_call(["git", "add", "file2.txt"])
 
-    rex("--no-commit", COMMIT)
+    assert rex("--no-commit", COMMIT).wait() == 0
 
     # Verify the file contains the right contents
     file_txt = open("file.txt").read().splitlines()

--- a/test/system/test_run_at_repository_root.py
+++ b/test/system/test_run_at_repository_root.py
@@ -33,7 +33,7 @@ def test_run_at_repository_root(rex, temp_git_repo):
     os.chdir("subdir")
 
     # Run git-rex
-    rex(COMMIT)
+    assert rex(COMMIT).wait() == 0
 
     # Verify the correct file was modified
     os.chdir("..")

--- a/test/system/test_script_sections.py
+++ b/test/system/test_script_sections.py
@@ -19,7 +19,7 @@ echo 'Line appended by rex-commit' >> file.txt
 def test_sections_run_as_separate_bash_script(rex, temp_git_repo):
     check_call(["git", "commit", "--allow-empty", "-m", TWO_SCRIPT_COMMIT_MESSAGE])
     COMMIT = check_output(["git", "rev-parse", "HEAD"], encoding="ascii").strip()
-    rex(COMMIT)
+    assert rex(COMMIT).wait() == 0
 
     # Verify the files contain the right contents
     file_txt = open("file.txt").read().splitlines()


### PR DESCRIPTION
Improve the rex fixture:

* Convert to using subprocess, so tests that need to communicate or capture stdout/stderr can use the fixture
* Integrate with the mock_editor fixture, so tests don't need to replicate setting up the subprocess environment