### PR TITLE
Use `git commit -C` if the message matches

### DIFF
--- a/git_rex/__init__.py
+++ b/git_rex/__init__.py
@@ -64,6 +64,8 @@ def edit_commit(commit: Optional[git.Commit], *, no_commit: bool) -> None:
     git.add_all()
     if no_commit:
         git.store_commit_message(commit_message)
+    elif commit and commit.message == commit_message:
+        git.commit_with_meta_from(commit)
     else:
         git.commit(commit_message)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-rex"
-version = "0.5.2"
+version = "0.5.3"
 description = ""
 authors = ["Alice Purcell <Alice.Purcell.39@gmail.com>"]
 


### PR DESCRIPTION
Rather than always dropping the original commit details if `--edit` is passed in, keep the original author and date if the message is not altered in the editor.