### PR TITLE
Refactor main

### DIFF
--- a/git_rex/__init__.py
+++ b/git_rex/__init__.py
@@ -77,11 +77,18 @@ def rex() -> None:
     if not is_clean:
         raise UnstagedChanges()
 
+    original_message = (
+        args.commit.message
+        if args.commit
+        else DEFAULT_COMMIT_TEMPLATE
+        if args.edit
+        else None
+    )
+    if original_message is None:
+        raise InvocationError()
+
     if args.edit:
         """git rex --edit [commit]"""
-        original_message = (
-            args.commit.message if args.commit else DEFAULT_COMMIT_TEMPLATE
-        )
         raw_edited_message = spawn_editor(
             original_message, filename=".git/COMMIT_EDITMSG"
         )
@@ -96,12 +103,11 @@ def rex() -> None:
             git.commit(commit_message)
     else:
         """git rex commit"""
-        if not args.commit:
-            raise InvocationError()
-        run_scripts(args.commit.message)
+        commit_message = original_message
+        run_scripts(commit_message)
         git.add_all()
         if args.no_commit:
-            git.store_commit_message(args.commit.message)
+            git.store_commit_message(commit_message)
         else:
             git.commit_with_meta_from(args.commit)
 

--- a/git_rex/__init__.py
+++ b/git_rex/__init__.py
@@ -36,6 +36,10 @@ The following commands were executed:
 """
 
 
+class InvocationError(Exception):
+    pass
+
+
 class UnstagedChanges(Exception):
     pass
 
@@ -104,9 +108,11 @@ def main() -> None:
             edit_commit(args.commit, no_commit=args.no_commit)
         else:
             if not args.commit:
-                parser().print_help()
-                sys.exit(64)
+                raise InvocationError()
             reexecute_commit(args.commit, no_commit=args.no_commit)
+    except InvocationError:
+        parser().print_help()
+        sys.exit(64)
     except UnstagedChanges:
         log.error("cannot reexecute: You have unstaged changes.")
         log.error("Please commit or stash them.")

--- a/git_rex/__init__.py
+++ b/git_rex/__init__.py
@@ -95,22 +95,26 @@ def parser() -> ArgumentParser:
     return parser
 
 
+def rex() -> None:
+    args = parser().parse_args()
+    os.chdir(git.top_level())
+
+    is_clean = git.no_unstaged_changes() if args.no_commit else git.is_clean_repo()
+    if not is_clean:
+        raise UnstagedChanges()
+
+    if args.edit:
+        edit_commit(args.commit, no_commit=args.no_commit)
+    else:
+        if not args.commit:
+            raise InvocationError()
+        reexecute_commit(args.commit, no_commit=args.no_commit)
+
+
 def main() -> None:
     configure_logging()
-    args = parser().parse_args()
     try:
-        os.chdir(git.top_level())
-
-        is_clean = git.no_unstaged_changes() if args.no_commit else git.is_clean_repo()
-        if not is_clean:
-            raise UnstagedChanges()
-
-        if args.edit:
-            edit_commit(args.commit, no_commit=args.no_commit)
-        else:
-            if not args.commit:
-                raise InvocationError()
-            reexecute_commit(args.commit, no_commit=args.no_commit)
+        rex()
     except InvocationError:
         parser().print_help()
         sys.exit(64)

--- a/git_rex/__init__.py
+++ b/git_rex/__init__.py
@@ -9,7 +9,8 @@ from .bash import UserCodeError
 from .editor import EditorError, EditorUnset, spawn_editor
 from .log_config import configure_logging
 from .messages import (
-    NoCodeFound,
+    NoExecutableCodeFound,
+    NoScriptBlockFound,
     UnexpectedCodeBlock,
     UnsupportedCodeSyntax,
     UnterminatedCodeBlock,
@@ -117,11 +118,11 @@ def main() -> None:
         log.error("cannot reexecute: You have unstaged changes.")
         log.error("Please commit or stash them.")
         sys.exit(64)
-    except NoCodeFound:
-        if args.edit:
-            log.fatal("Aborting commit as no code found to execute")
-        else:
-            log.fatal("No code section found in commit")
+    except NoScriptBlockFound:
+        log.fatal("No code section found in commit")
+        sys.exit(64)
+    except NoExecutableCodeFound:
+        log.fatal("Aborting commit as no code found to execute")
         sys.exit(64)
     except UnsupportedCodeSyntax as e:
         log.fatal("%d: Code sections must specify bash syntax", e.lineno)

--- a/git_rex/__init__.py
+++ b/git_rex/__init__.py
@@ -93,23 +93,19 @@ def rex() -> None:
             original_message, filename=".git/COMMIT_EDITMSG"
         )
         commit_message = cleanup_message(raw_edited_message)
-        run_scripts(commit_message)
-        git.add_all()
-        if args.no_commit:
-            git.store_commit_message(commit_message)
-        elif args.commit and args.commit.message == commit_message:
-            git.commit_with_meta_from(args.commit)
-        else:
-            git.commit(commit_message)
     else:
         """git rex commit"""
         commit_message = original_message
-        run_scripts(commit_message)
-        git.add_all()
-        if args.no_commit:
-            git.store_commit_message(commit_message)
-        else:
-            git.commit_with_meta_from(args.commit)
+
+    run_scripts(commit_message)
+    git.add_all()
+
+    if args.no_commit:
+        git.store_commit_message(commit_message)
+    elif args.commit and args.commit.message == commit_message:
+        git.commit_with_meta_from(args.commit)
+    else:
+        git.commit(commit_message)
 
 
 def main() -> None:

--- a/git_rex/__init__.py
+++ b/git_rex/__init__.py
@@ -2,6 +2,7 @@ import os
 import sys
 from argparse import ArgumentParser
 from logging import getLogger
+from typing import Optional
 
 from . import git
 from .bash import UserCodeError
@@ -61,6 +62,17 @@ def run_scripts(commit_message: str) -> None:
         script.execute()
 
 
+def commit(
+    commit_message: str, original_commit: Optional[git.Commit], *, no_commit: bool
+) -> None:
+    if no_commit:
+        git.store_commit_message(commit_message)
+    elif original_commit and original_commit.message == commit_message:
+        git.commit_with_meta_from(original_commit)
+    else:
+        git.commit(commit_message)
+
+
 def parser() -> ArgumentParser:
     parser = ArgumentParser(
         description="Reapplies a commit by running commands from the commit message",
@@ -93,13 +105,7 @@ def rex() -> None:
 
     run_scripts(commit_message)
     git.add_all()
-
-    if args.no_commit:
-        git.store_commit_message(commit_message)
-    elif args.commit and args.commit.message == commit_message:
-        git.commit_with_meta_from(args.commit)
-    else:
-        git.commit(commit_message)
+    commit(commit_message, args.commit, no_commit=args.no_commit)
 
 
 def main() -> None:

--- a/git_rex/messages.py
+++ b/git_rex/messages.py
@@ -6,7 +6,11 @@ from .bash import BashScript
 CODE_BLOCK = re.compile(r"\s*```(\w*)\s*$")
 
 
-class NoCodeFound(Exception):
+class NoScriptBlockFound(Exception):
+    pass
+
+
+class NoExecutableCodeFound(Exception):
     pass
 
 
@@ -108,7 +112,7 @@ def extract_scripts(message: str) -> Tuple[BashScript, ...]:
             code_blocks.append(BashScript(first_lineno, tuple(code_lines)))
             code_lines.clear()
     if not code_blocks:
-        raise NoCodeFound()
+        raise NoScriptBlockFound()
     return tuple(code_blocks)
 
 
@@ -126,5 +130,5 @@ def cleanup_message(message: str) -> str:
                 continue
         lines.append(f"{line.text}\n")
     if not code_line_found:
-        raise NoCodeFound()
+        raise NoExecutableCodeFound()
     return "".join(lines)

--- a/test/unit/test_cleanup_message.py
+++ b/test/unit/test_cleanup_message.py
@@ -1,7 +1,7 @@
 import pytest
 
 from git_rex.messages import (
-    NoCodeFound,
+    NoExecutableCodeFound,
     UnexpectedCodeBlock,
     UnsupportedCodeSyntax,
     UnterminatedCodeBlock,
@@ -16,7 +16,7 @@ def test_removes_comments_only_outside_of_code_blocks():
 
 
 def test_no_code_block():
-    with pytest.raises(NoCodeFound):
+    with pytest.raises(NoExecutableCodeFound):
         cleanup_message("Some commit\n\nNo code")
 
 
@@ -40,5 +40,5 @@ def test_label_on_closing_ticks():
 
 
 def test_only_blank_lines_and_comments_in_code():
-    with pytest.raises(NoCodeFound):
+    with pytest.raises(NoExecutableCodeFound):
         cleanup_message("Some commit\n\n```bash\n\n# a comment\n\n```")

--- a/test/unit/test_extract_scripts.py
+++ b/test/unit/test_extract_scripts.py
@@ -1,7 +1,7 @@
 import pytest
 
 from git_rex.messages import (
-    NoCodeFound,
+    NoScriptBlockFound,
     UnexpectedCodeBlock,
     UnsupportedCodeSyntax,
     UnterminatedCodeBlock,
@@ -10,7 +10,7 @@ from git_rex.messages import (
 
 
 def test_no_code_block():
-    with pytest.raises(NoCodeFound):
+    with pytest.raises(NoScriptBlockFound):
         extract_scripts("Some commit\n\nNo code")
 
 


### PR DESCRIPTION
Tackle two code smells:

* main() method is quite long and complex
*  `reexecute_commit` and `edit_commit` often change together

Steps taken:
* Factor out an InvocationError, to move the last log/exit path into an exception handler like the rest
* Split NoCodeFound into two exceptions, so there is no conditional code in the exception handling logic
* Factor the body of `main` out into a separate `rex` method
* Inline `reexecute_commit` and `edit_commit` into it
* Refactor it into multiple small conditional block instead of two large ones
* Factor out methods from it